### PR TITLE
Fix ::Bulk compatibility with ES5.0

### DIFF
--- a/lib/Log/Log4perl/Appender/Elasticsearch/Bulk.pm
+++ b/lib/Log/Log4perl/Appender/Elasticsearch/Bulk.pm
@@ -63,7 +63,7 @@ sub _flush {
     scalar(@{$buff}) || return;
 
     foreach (@{$buff}) {
-        $data .= join $/, '{"create":{}}', $self->_to_json($_), '';
+        $data .= join $/, '{"index":{}}', $self->_to_json($_), '';
     }
 
     if (_INTERNAL_DEBUG) {


### PR DESCRIPTION
ElasticSearch 5.0 now requires an explicit id when using op_type=create
We should use op_type=index instead.

Reference: https://github.com/elastic/elasticsearch/issues/21535